### PR TITLE
Fix date format for Rails parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'momentjs-rails'
 gem 'bootstrap3-datetimepicker-rails'
 gem 'datetimepicker-rails', github: 'zpaulovics/datetimepicker-rails', branch: 'master', submodules: true
 gem 'geocoder'
+gem 'american_date'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     acts_as_tenant (0.3.9)
       rails (>= 3.1)
       request_store (>= 1.0.5)
+    american_date (1.1.1)
     arbre (1.0.3)
       activesupport (>= 3.0.0)
     arel (6.0.3)
@@ -363,6 +364,7 @@ DEPENDENCIES
   aasm
   activeadmin (~> 1.0.0.pre2)
   acts_as_tenant
+  american_date
   bootstrap-sass
   bootstrap3-datetimepicker-rails
   bower-rails

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,5 +24,5 @@ en:
     dformat: '%m/%d/%Y'
     pformat: 'MM/DD/YYYY'
   timepicker:
-    dformat: 'h:mm a'
+    dformat: '%R'
     pformat: 'h:mm a'

--- a/vendor/assets/javascripts/pickers.js
+++ b/vendor/assets/javascripts/pickers.js
@@ -2,7 +2,6 @@ $(document).on('ready page:change', function() {
   $('.datetimepicker').datetimepicker({
     // put here your custom picker options, that should be applied for all pickers
     stepping: 15,
-    viewMode: 'months',
     showClear: true,
     icons: {
       date: 'fa fa-calendar',


### PR DESCRIPTION
[ruby-american-date](https://github.com/jeremyevans/ruby-american_date)

Rails was switching the month and day fields when saving to the database which was making some of the dates invalid. This gem fixes that problem. 