### PR TITLE
Imported users/events are associated with a chapter

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,7 +18,7 @@ class EventsController < InheritedResources::Base
   end
 
   def import_events
-    Event.import params[:event_file]
+    Event.import params[:event_file], ActsAsTenant.current_tenant
     redirect_to :back, notice: 'Event data has been imported'
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -91,7 +91,7 @@ class UsersController < InheritedResources::Base
   end
 
   def import
-    User.import params[:user_file]
+    User.import params[:user_file], ActsAsTenant.current_tenant
     redirect_to :admin_dashboard, notice: 'User data has been imported'
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,9 +17,10 @@ class Event < ActiveRecord::Base
     attendees.size
   end
 
-  def self.import file
+  def self.import file, chapter
     CSV.foreach(file.path, headers: true) do |row|
-      Event.create! row.to_hash
+      event = Event.create! row.to_hash
+      event.update(organization_id: chapter.id)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,9 +44,10 @@ class User < ActiveRecord::Base
     self.role ||= :guest
   end
 
-  def self.import file
+  def self.import file, chapter
     CSV.foreach(file.path, headers: true) do |row|
-      User.create! row.to_hash
+      user = User.create! row.to_hash
+      Membership.create!(organization_id: chapter.id, member_id: user.id, admin: false)
     end
   end
 


### PR DESCRIPTION
When an admin is adding users or events with a CSV, this change makes sure that:
- a membership gets created for each user under that admin's chapter
- events that are created get assigned to that admin's chapter